### PR TITLE
Add disable_warnings to config.rb

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -7,3 +7,4 @@ javascripts_dir = 'assets/javascripts'
 relative_assets = true
 line_comments = false
 # output_style = :compressed
+disable_warnings = true


### PR DESCRIPTION
Add disable_warnings to disable the @media query/@extend deprecation warnings.
