### PR TITLE
Add empty 'ignore' key to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,5 +9,7 @@
   "main": [
     "assets/stylesheets/unsemantic-grid-responsive-no-ie7.css",
     "assets/stylesheets/unsemantic-grid-responsive-tablet-no-ie7.css"
+  ],
+  "ignore": [
   ]
 }


### PR DESCRIPTION
This is to prevent the following notice on install:

`bower unsemantic#*        invalid-meta unsemantic is missing "ignore" entry in bower.json`
