### PR TITLE
Update stable version for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "unsemantic",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Fluid grid for mobile, tablet, and desktop.",
   "license": [
     "GPL",


### PR DESCRIPTION
When u tray install using bower send this message...

bower unsemantic#*          not-cached git://github.com/nathansmith/unsemantic.git#*
bower unsemantic#*             resolve git://github.com/nathansmith/unsemantic.git#*
bower unsemantic#*            download https://github.com/nathansmith/unsemantic/archive/1.0.2.tar.gz
bower unsemantic#*             extract archive.tar.gz
bower unsemantic#*            mismatch Version declared in the json (1.0.1) is different than the resolved one (1.0.2)
bower unsemantic#*            resolved git://github.com/nathansmith/unsemantic.git#1.0.2
bower unsemantic#~1.0.2        install unsemantic#1.0.2