### PR TITLE
fix: specifying "main" in npm breaks webpack setups

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "unsemantic",
   "version": "1.1.2",
   "description": "Fluid grid for mobile, tablet, and desktop.",
-  "main": "./assets/react/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
is it reasonable to omit the `main` entry altogether? 

when installing via npm and building with webpack, this breaks the webpack build as the `./assets/react/index.js` will be picked up as a module and bundled, causing broken dependencies (if you don't want react in the project).

BTW, thanx! unsemantic is awesome!