### PR TITLE
Created lib for projects that depend on pre-transpiled modules.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["env", "react"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.scssc
 *.sassc
+node_modules

--- a/assets/react/index.js
+++ b/assets/react/index.js
@@ -8,10 +8,10 @@
 */
 
 // Import.
-import Grid from './assets/react/grid'
-import GridClear from './assets/react/grid_clear'
-import GridContainer from './assets/react/grid_container'
-import GridOffset from './assets/react/grid_offset'
+import Grid from './grid'
+import GridClear from './grid_clear'
+import GridContainer from './grid_container'
+import GridOffset from './grid_offset'
 
 // Export.
 export { Grid }

--- a/lib/grid.js
+++ b/lib/grid.js
@@ -1,0 +1,217 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } // Dependencies.
+
+
+// Define class.
+var Grid = function (_React$Component) {
+  _inherits(Grid, _React$Component);
+
+  function Grid() {
+    _classCallCheck(this, Grid);
+
+    return _possibleConstructorReturn(this, (Grid.__proto__ || Object.getPrototypeOf(Grid)).apply(this, arguments));
+  }
+
+  _createClass(Grid, [{
+    key: 'render',
+
+    // Render method.
+    value: function render() {
+      var parent = this.props.parent;
+
+      var desktop = this.props.desktop;
+      var desktopHide = this.props['desktop-hide'];
+      var desktopPush = this.props['desktop-push'];
+      var desktopPull = this.props['desktop-pull'];
+      var desktopPrefix = this.props['desktop-prefix'];
+      var desktopSuffix = this.props['desktop-suffix'];
+
+      var mobile = this.props.mobile;
+      var mobileHide = this.props['mobile-hide'];
+      var mobilePush = this.props['mobile-push'];
+      var mobilePull = this.props['mobile-pull'];
+      var mobilePrefix = this.props['mobile-prefix'];
+      var mobileSuffix = this.props['mobile-suffix'];
+
+      var tablet = this.props.tablet;
+      var tabletHide = this.props['tablet-hide'];
+      var tabletPush = this.props['tablet-push'];
+      var tabletPull = this.props['tablet-pull'];
+      var tabletPrefix = this.props['tablet-prefix'];
+      var tabletSuffix = this.props['tablet-suffix'];
+
+      // Populated later.
+      var className = [];
+
+      /*
+        ===================
+        PARENT CLASS NAMES.
+        ===================
+      */
+
+      if (parent) {
+        className.push('grid-parent');
+      }
+
+      /*
+        ====================
+        DESKTOP CLASS NAMES.
+        ====================
+      */
+
+      if (desktop) {
+        className.push('grid-' + desktop);
+      }
+
+      if (desktopHide) {
+        className.push('hide-on-desktop');
+      }
+
+      if (desktopPush) {
+        className.push('push-' + desktopPush);
+      }
+
+      if (desktopPull) {
+        className.push('pull-' + desktopPull);
+      }
+
+      if (desktopPrefix) {
+        className.push('prefix-' + desktopPrefix);
+      }
+
+      if (desktopSuffix) {
+        className.push('suffix-' + desktopSuffix);
+      }
+
+      /*
+        ===================
+        MOBILE CLASS NAMES.
+        ===================
+      */
+
+      if (mobile) {
+        className.push('mobile-grid-' + mobile);
+      }
+
+      if (mobileHide) {
+        className.push('hide-on-mobile');
+      }
+
+      if (mobilePush) {
+        className.push('mobile-push-' + mobilePush);
+      }
+
+      if (mobilePull) {
+        className.push('mobile-pull-' + mobilePull);
+      }
+
+      if (mobilePrefix) {
+        className.push('mobile-prefix-' + mobilePrefix);
+      }
+
+      if (mobileSuffix) {
+        className.push('mobile-suffix-' + mobileSuffix);
+      }
+
+      /*
+        ===================
+        TABLET CLASS NAMES.
+        ===================
+      */
+
+      if (tablet) {
+        className.push('tablet-grid-' + tablet);
+      }
+
+      if (tabletHide) {
+        className.push('hide-on-tablet');
+      }
+
+      if (tabletPush) {
+        className.push('tablet-push-' + tabletPush);
+      }
+
+      if (tabletPull) {
+        className.push('tablet-pull-' + tabletPull);
+      }
+
+      if (tabletPrefix) {
+        className.push('tablet-prefix-' + tabletPrefix);
+      }
+
+      if (tabletSuffix) {
+        className.push('tablet-suffix-' + tabletSuffix);
+      }
+
+      /*
+        =================
+        BUILD THE MARKUP.
+        =================
+      */
+
+      className = className.join(' ');
+
+      // Expose UI.
+      return _react2.default.createElement(
+        'div',
+        { className: className },
+        this.props.children
+      );
+    }
+  }]);
+
+  return Grid;
+}(_react2.default.Component);
+
+// Validation
+
+
+Grid.propTypes = {
+  children: _propTypes2.default.node,
+
+  parent: _propTypes2.default.bool,
+
+  desktop: _propTypes2.default.string,
+  'desktop-hide': _propTypes2.default.bool,
+  'desktop-push': _propTypes2.default.string,
+  'desktop-pull': _propTypes2.default.string,
+  'desktop-prefix': _propTypes2.default.string,
+  'desktop-suffix': _propTypes2.default.string,
+
+  mobile: _propTypes2.default.string,
+  'mobile-hide': _propTypes2.default.bool,
+  'mobile-push': _propTypes2.default.string,
+  'mobile-pull': _propTypes2.default.string,
+  'mobile-prefix': _propTypes2.default.string,
+  'mobile-suffix': _propTypes2.default.string,
+
+  tablet: _propTypes2.default.string,
+  'tablet-hide': _propTypes2.default.bool,
+  'tablet-push': _propTypes2.default.string,
+  'tablet-pull': _propTypes2.default.string,
+  'tablet-prefix': _propTypes2.default.string,
+  'tablet-suffix': _propTypes2.default.string
+
+  // Export.
+};exports.default = Grid;

--- a/lib/grid_clear.js
+++ b/lib/grid_clear.js
@@ -1,0 +1,103 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } // Dependencies.
+
+
+// Define class.
+var GridClear = function (_React$Component) {
+  _inherits(GridClear, _React$Component);
+
+  function GridClear() {
+    _classCallCheck(this, GridClear);
+
+    return _possibleConstructorReturn(this, (GridClear.__proto__ || Object.getPrototypeOf(GridClear)).apply(this, arguments));
+  }
+
+  _createClass(GridClear, [{
+    key: 'render',
+
+    // Render method.
+    value: function render() {
+      var desktopHide = this.props['desktop-hide'];
+      var mobileHide = this.props['mobile-hide'];
+      var tabletHide = this.props['tablet-hide'];
+
+      // Populated later.
+      var className = ['clear'];
+
+      /*
+        ====================
+        DESKTOP CLASS NAMES.
+        ====================
+      */
+
+      if (desktopHide) {
+        className.push('hide-on-desktop');
+      }
+
+      /*
+        ===================
+        MOBILE CLASS NAMES.
+        ===================
+      */
+
+      if (mobileHide) {
+        className.push('hide-on-mobile');
+      }
+
+      /*
+        ===================
+        TABLET CLASS NAMES.
+        ===================
+      */
+
+      if (tabletHide) {
+        className.push('hide-on-tablet');
+      }
+
+      /*
+        =================
+        BUILD THE MARKUP.
+        =================
+      */
+
+      className = className.join(' ');
+
+      // Expose UI.
+      return _react2.default.createElement('span', { className: className });
+    }
+  }]);
+
+  return GridClear;
+}(_react2.default.Component);
+
+// Validation.
+
+
+GridClear.propTypes = {
+  'desktop-hide': _propTypes2.default.bool,
+  'mobile-hide': _propTypes2.default.bool,
+  'tablet-hide': _propTypes2.default.bool
+
+  // Export.
+};exports.default = GridClear;

--- a/lib/grid_container.js
+++ b/lib/grid_container.js
@@ -1,0 +1,60 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } // Dependencies.
+
+
+// Define class.
+var GridContainer = function (_React$Component) {
+  _inherits(GridContainer, _React$Component);
+
+  function GridContainer() {
+    _classCallCheck(this, GridContainer);
+
+    return _possibleConstructorReturn(this, (GridContainer.__proto__ || Object.getPrototypeOf(GridContainer)).apply(this, arguments));
+  }
+
+  _createClass(GridContainer, [{
+    key: 'render',
+
+    // Render method.
+    value: function render() {
+      // Expose UI.
+      return _react2.default.createElement(
+        'div',
+        { className: 'grid-container' },
+        this.props.children
+      );
+    }
+  }]);
+
+  return GridContainer;
+}(_react2.default.Component);
+
+// Validation.
+
+
+GridContainer.propTypes = {
+  children: _propTypes2.default.node
+
+  // Export.
+};exports.default = GridContainer;

--- a/lib/grid_offset.js
+++ b/lib/grid_offset.js
@@ -1,0 +1,60 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } // Dependencies.
+
+
+// Define class.
+var GridOffset = function (_React$Component) {
+  _inherits(GridOffset, _React$Component);
+
+  function GridOffset() {
+    _classCallCheck(this, GridOffset);
+
+    return _possibleConstructorReturn(this, (GridOffset.__proto__ || Object.getPrototypeOf(GridOffset)).apply(this, arguments));
+  }
+
+  _createClass(GridOffset, [{
+    key: 'render',
+
+    // Render method.
+    value: function render() {
+      // Expose UI.
+      return _react2.default.createElement(
+        'div',
+        { className: 'grid-offset' },
+        this.props.children
+      );
+    }
+  }]);
+
+  return GridOffset;
+}(_react2.default.Component);
+
+// Validation.
+
+
+GridOffset.propTypes = {
+  children: _propTypes2.default.node
+
+  // Export.
+};exports.default = GridOffset;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,40 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.GridOffset = exports.GridContainer = exports.GridClear = exports.Grid = undefined;
+
+var _grid = require('./grid');
+
+var _grid2 = _interopRequireDefault(_grid);
+
+var _grid_clear = require('./grid_clear');
+
+var _grid_clear2 = _interopRequireDefault(_grid_clear);
+
+var _grid_container = require('./grid_container');
+
+var _grid_container2 = _interopRequireDefault(_grid_container);
+
+var _grid_offset = require('./grid_offset');
+
+var _grid_offset2 = _interopRequireDefault(_grid_offset);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// Export.
+/*
+  // This file exists for use with NPM and React.
+  // It is not meant to be loaded into a browser.
+
+  // Example...
+
+  import { Grid, GridContainer } from 'unsemantic'
+*/
+
+// Import.
+exports.Grid = _grid2.default;
+exports.GridClear = _grid_clear2.default;
+exports.GridContainer = _grid_container2.default;
+exports.GridOffset = _grid_offset2.default;

--- a/package.json
+++ b/package.json
@@ -6,8 +6,15 @@
     "prop-types": "^15.5.10",
     "react": "^15.5.10"
   },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
+    "rimraf": "^2.6.2"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "clean": "rimraf lib",
+    "compile": "npm run clean && babel assets/react -d lib"
   },
   "repository": {
     "type": "git",
@@ -27,5 +34,6 @@
   "bugs": {
     "url": "https://github.com/nathansmith/unsemantic/issues"
   },
-  "homepage": "https://github.com/nathansmith/unsemantic#readme"
+  "homepage": "https://github.com/nathansmith/unsemantic#readme",
+  "main": "lib/index.js"
 }


### PR DESCRIPTION
My project is bundled using webpack, where we ```exclude: /node_modules/``` in the babel-loader config. As a result, any packages under our node_modules directory that are not pre-transpiled error out during build.

As most packages I've seen are pre-transpiled prior to publishing, I thought unsemantic could benefit from doing this.