### PR TITLE
Adds ability to provide a custom className to Grid component.

### DIFF
--- a/assets/react/dist/grid.js
+++ b/assets/react/dist/grid.js
@@ -61,6 +61,8 @@ var Grid = function (_React$Component) {
       var tabletPrefix = this.props['tablet-prefix'];
       var tabletSuffix = this.props['tablet-suffix'];
 
+      var customClassName = this.props['className'];
+
       // Populated later.
       var className = [];
 
@@ -162,6 +164,10 @@ var Grid = function (_React$Component) {
 
       if (tabletSuffix) {
         className.push('tablet-suffix-' + tabletSuffix);
+      }
+
+      if (customClassName) {
+        className.push(customClassName);
       }
 
       /*

--- a/assets/react/source/grid.js
+++ b/assets/react/source/grid.js
@@ -29,6 +29,8 @@ class Grid extends React.Component {
     const tabletPrefix = this.props['tablet-prefix']
     const tabletSuffix = this.props['tablet-suffix']
 
+    const customClassName = this.props['className']
+
     // Populated later.
     let className = []
 
@@ -130,6 +132,10 @@ class Grid extends React.Component {
 
     if (tabletSuffix) {
       className.push('tablet-suffix-' + tabletSuffix)
+    }
+
+    if (customClassName) {
+      className.push(customClassName)
     }
 
     /*


### PR DESCRIPTION
There are cases where we would like to add our own custom classNames to the Grid component without adding additional elements.

For example, we add ```.gutter-bottom``` to a lot of our grid cells. Using the current react components, we either have to add this class to the inner elements, which are used elsewhere outside of a grid, or add an additional wrapper to apply the className, which we feel adds unnecessary markup.

**React Source**
```jsx
<Grid mobile="50" tablet="33" desktop="25" className="gutter-bottom">...</Grid>
```

**Compiled HTML**
```html
<div class="grid-25 tablet-grid-33 mobile-grid-50 gutter-bottom">...</div>
```

This also addresses the https://github.com/nathansmith/unsemantic/issues/94 feature request.